### PR TITLE
Fixed PeopleCode grammar to allow for output variables.

### DIFF
--- a/grammars/PeopleCode.g4
+++ b/grammars/PeopleCode.g4
@@ -99,7 +99,7 @@ setImpl     : 'set' GENERIC_ID stmtList endset='end-set' ;
 
 funcImpl        : funcSignature stmtList endfunction='End-Function' ;
 funcSignature   : 'Function' GENERIC_ID formalParamList? returnType? ';'? ;
-formalParamList : '(' ( param (',' param)* )? ')' ;
+formalParamList : '(' ( param 'out'? (',' param 'out'?)* )? ')' ;
 param           : VAR_ID ('As' varType)? ;
 returnType      : 'Returns' varType ;
 

--- a/grammars/PeopleCode.g4
+++ b/grammars/PeopleCode.g4
@@ -132,7 +132,7 @@ id  : SYS_VAR_ID | VAR_ID | GENERIC_ID ;
 
 DecimalLiteral  : IntegerLiteral '.' [0-9]+ ;
 IntegerLiteral  : '0' | '1'..'9' '0'..'9'* ;
-StringLiteral   : '"' ( ~'"' )* '"' ;
+StringLiteral   : '"' (~'"'|'""')* '"' ;
 BoolLiteral     :   'True' | 'False' ;
 
 VAR_ID      : '&' GENERIC_ID ;


### PR DESCRIPTION
Example:
```
method Login(&user as string, &token as string out);
```